### PR TITLE
feat(image): 新增图片路径的年月日配置项

### DIFF
--- a/hexoweb/libs/image/providers/alioss.py
+++ b/hexoweb/libs/image/providers/alioss.py
@@ -10,7 +10,7 @@ from time import time
 from hashlib import md5
 
 from ..core import Provider
-
+from ..replace import replace_path
 
 class AliOss(Provider):
     name = '阿里云OSS'
@@ -35,9 +35,8 @@ class AliOss(Provider):
         now = date.today()
         photo_stream = file.read()
         file_md5 = md5(photo_stream).hexdigest()
-        path = self.path.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace("{md5}",
-                                                                                                                                  file_md5)
+        path = replace_path(self.path,file)
+
         # 处理路径开头斜杠
         path = path[1:] if path.startswith("/") else path
 
@@ -49,6 +48,4 @@ class AliOss(Provider):
 
         bucket.put_object(path, photo_stream, headers={"Content-Type": file.content_type})
 
-        return self.prev_url.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace(
-            "{md5}", file_md5)
+        return replace_path(self.prev_url,file)

--- a/hexoweb/libs/image/providers/dogecloudoss.py
+++ b/hexoweb/libs/image/providers/dogecloudoss.py
@@ -14,6 +14,7 @@ import json
 import urllib
 
 from ..core import Provider
+from ..replace import replace_path
 
 
 class DogeCloudOss(Provider):
@@ -57,9 +58,8 @@ class DogeCloudOss(Provider):
         now = date.today()
         photo_stream = file.read()
         file_md5 = md5(photo_stream).hexdigest()
-        path = self.path.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace("{md5}",
-                                                                                                                                  file_md5)
+        path = replace_path(self.path,file)
+        
         res = self.dogecloud_api()
         if res['code'] != 200:
             raise Exception("Api failed: " + res['msg'])
@@ -76,6 +76,4 @@ class DogeCloudOss(Provider):
         bucket.put_object(Key=path, Body=photo_stream,
                           ContentType=file.content_type)
 
-        return self.prev_url.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace(
-            "{md5}", file_md5)
+        return replace_path(self.prev_url,file)

--- a/hexoweb/libs/image/providers/ftp.py
+++ b/hexoweb/libs/image/providers/ftp.py
@@ -9,7 +9,7 @@ from time import time
 from datetime import date
 
 from ..core import Provider
-
+from ..replace import replace_path
 
 class Ftp(Provider):
     name = 'FTP协议'
@@ -38,13 +38,8 @@ class Ftp(Provider):
         ftp.connect(self.host, int(self.port))
         ftp.login(self.user, self.password)
         now = date.today()
-        path = self.path.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}",
-                                                                                                     str(now.day)) \
-            .replace("{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{time}", str(time())) \
-            .replace("{extName}", file.name.split(".")[-1])
+        path = replace_path(self.path,file)
+
         bufsize = 1024
         ftp.storbinary('STOR ' + path, file, bufsize)
-        return self.prev_url.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}",
-                                                                                                         str(now.day)) \
-            .replace("{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{time}", str(time())) \
-            .replace("{extName}", file.name.split(".")[-1])
+        return replace_path(self.prev_url,file)

--- a/hexoweb/libs/image/providers/gitHub.py
+++ b/hexoweb/libs/image/providers/gitHub.py
@@ -9,6 +9,7 @@ from datetime import date
 from hashlib import md5
 from time import time
 from ..core import Provider
+from ..replace import replace_path
 
 
 class Github(Provider):
@@ -34,9 +35,8 @@ class Github(Provider):
         now = date.today()
         photo_stream = file.read()
         file_md5 = md5(photo_stream).hexdigest()
-        path = self.path.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace("{md5}",
-                                                                                                                                  file_md5).replace("{time}", str(time()))
+        path = replace_path(self.path,file)
+
         commitchange = "Upload {} by Qexo".format(file.name)
         try:
             self.repo.update_file(path, commitchange, photo_stream,
@@ -44,6 +44,4 @@ class Github(Provider):
         except:
             self.repo.create_file(path, commitchange, photo_stream, branch=self.branch)
 
-        return self.url.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace(
-            "{md5}", file_md5).replace("{time}", str(time()))
+        return replace_path(self.url,file)

--- a/hexoweb/libs/image/providers/s3.py
+++ b/hexoweb/libs/image/providers/s3.py
@@ -6,10 +6,10 @@
 
 from datetime import date
 import boto3
-from time import time
 from hashlib import md5
 
 from ..core import Provider
+from ..replace import replace_path
 
 
 class S3(Provider):
@@ -35,9 +35,7 @@ class S3(Provider):
         now = date.today()
         photo_stream = file.read()
         file_md5 = md5(photo_stream).hexdigest()
-        path = self.path.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace("{md5}",
-                                                                                                                                  file_md5)
+        path = replace_path(self.path,file)
 
         s3 = boto3.resource(
             service_name='s3',
@@ -49,6 +47,4 @@ class S3(Provider):
         bucket = s3.Bucket(self.bucket)
         bucket.put_object(Key=path, Body=photo_stream, ContentType=file.content_type)
 
-        return self.prev_url.replace("{year}", str(now.year)).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
-            "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace(
-            "{md5}", file_md5)
+        return replace_path(self.prev_url,file)

--- a/hexoweb/libs/image/replace.py
+++ b/hexoweb/libs/image/replace.py
@@ -1,0 +1,27 @@
+"""
+@Project   : image
+@Author    : abudu
+@Blog      : https://www.oplog.cn
+"""
+from datetime import date
+from hashlib import md5
+from time import time
+
+def replace_path(path:str,file):
+    """替换图片url的函数"""
+    now = date.today()
+    photo_stream = file.read()
+    file_md5 = md5(photo_stream).hexdigest()
+    # {year} 23
+    # {month} 6
+    # {day}   3
+    path = path.replace("{year}", str(now.year)[-2:]).replace("{month}", str(now.month)).replace("{day}", str(now.day)).replace(
+        "{filename}", file.name[0:-len(file.name.split(".")[-1]) - 1]).replace("{extName}", file.name.split(".")[-1]).replace("{md5}",
+                                                                                                                                file_md5).replace("{time}", str(time()))
+    # {YEAR} 2023
+    # {MONTH} 06
+    # {DAY}   03
+    path = path.replace("{YEAR}",str(now.year)).replace("{MONTH}",str(now.month).zfill(2)).replace(
+        "{DAY}",str(now.day).zfill(2))
+
+    return path


### PR DESCRIPTION
新增图片路径包含前导0的月/日配置项，新增年分大小配置项（2023和23）

除github外，其他配置项似乎并没有添加`{time}`的replace，我统一封装了一个函数来处理

需要修改文档 https://www.oplog.cn/qexo/configs/upload.html#%E4%BF%9D%E5%AD%98%E8%B7%AF%E5%BE%84-2

>文档里面的这个`保存路径`似乎并没有出现在右侧大纲上，感觉需要弄上