### PR TITLE
fix: 通知邮件内容中的html不被邮箱解析

### DIFF
--- a/hexoweb/libs/onepush/providers/smtp.py
+++ b/hexoweb/libs/onepush/providers/smtp.py
@@ -23,7 +23,7 @@ def _default_message_parser(
     # Send to yourself if `To` address not provided
     msg["To"] = To or user
 
-    msg.set_content(content)
+    msg.add_alternative(content, subtype='html')
     return msg
 
 


### PR DESCRIPTION
当我部署完毕友链申请组件后，提交了一个友链申请，作为测试。但是，邮件内容中的换行符`<br>`被直接显示了出来，并没有按照预期在该处换行。下图中，我尝试邮件内容在前后加入`table`标签，试图让邮箱解析html，但没有效果。

> ![无法解析换行符](https://github.com/Qexo/Qexo/assets/79385954/e682ff8a-8028-49b0-93db-39b03cb52570)

随即，我查看了信件的信头，显示此封邮件的内容类型（Content-Type）值为`text/plain; charset="utf-8"`，而并非`text/html; charset="utf-8"`。然后我替换了SMTP发件部分的一行代码并保存，问题得以解决。

- 📚 https://roytuts.com/how-to-send-an-html-email-using-python/