### PR TITLE
本地服务商部署支持 Windows Powershell

### DIFF
--- a/hexoweb/libs/platforms/providers/local.py
+++ b/hexoweb/libs/platforms/providers/local.py
@@ -78,5 +78,10 @@ class Local(Provider):
         if not self.auto:
             return False
         logging.info("进行自动部署...")
-        p = subprocess.Popen("cd {} && {}".format(self.path, self.auto), shell=True)
+        if os.name == 'nt':
+            exec_cmd = "powershell \"cd {}; {}\"".format(self.path, self.auto)
+        else:
+            exec_cmd = "cd {} && {}".format(self.path, self.auto)
+        logging.error(exec_cmd)
+        p = subprocess.Popen(exec_cmd, shell=True)
         return p


### PR DESCRIPTION
服务商为本地时，当前版本仅支持 Linux 下的部署。该修改增加了对 Windows 的支持。考虑到 cmd 下不太容易 cd 到带盘符的绝对路径，就用 Powershell 调用。相应地，自动部署命令也要以 Powershell 的方式写。

![image](https://github.com/Qexo/Qexo/assets/11372753/3cdac0f9-6b9f-4bf1-8919-a6db5e4f9ff7)
