### PR TITLE
upgrade dep ver to fix vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==3.2.18
+Django==3.2.19
 PyMySQL==1.0.2
 boto3==1.26.94
-requests==2.28.2
+requests==2.31.0
 PyGithub==1.58.1
 python-gitlab==3.13.0
 html2text==2020.1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.19
+Django==3.2.20
 PyMySQL==1.0.2
 boto3==1.26.94
 requests==2.31.0

--- a/requirements_withoutmsyql.txt
+++ b/requirements_withoutmsyql.txt
@@ -1,6 +1,6 @@
-Django==3.2.18
+Django==3.2.19
 boto3==1.26.94
-requests==2.28.2
+requests==2.31.0
 PyGithub==1.58.1
 python-gitlab==3.13.0
 html2text==2020.1.16

--- a/requirements_withoutmsyql.txt
+++ b/requirements_withoutmsyql.txt
@@ -1,4 +1,4 @@
-Django==3.2.19
+Django==3.2.20
 boto3==1.26.94
 requests==2.31.0
 PyGithub==1.58.1


### PR DESCRIPTION
Fix 3 vulnerabilities:

- CVE-2023-31047 (from django 3.2.18)
- CVE-2023-36053 (from django 3.2.18)
- CVE-2023-32681 (from requests 2.28.2)

Tests may be needed.

A vulnerability cannot be fixed due to djongo 1.3.6 depends on it:

- CVE-2023-30608 (from sqlparse 0.2.4)