### PR TITLE
vditor 的 ir 模式有 bug，故先把默认编辑模式改回去

### DIFF
--- a/templates/home/edit.html
+++ b/templates/home/edit.html
@@ -341,7 +341,7 @@
                     "enable": false
                 },
                 "value": {{ file_content|safe }},
-                "mode": "ir",
+                "mode": "wysiwyg",
                 "debugger": false,
                 "preview": {
                     "mode": "both",

--- a/templates/home/edit_page.html
+++ b/templates/home/edit_page.html
@@ -305,7 +305,7 @@
                     "enable": false
                 },
                 "value": {{ file_content|safe }},
-                "mode": "ir",
+                "mode": "wysiwyg",
                 "debugger": false,
                 "preview": {
                     "mode": "both",

--- a/templates/home/new.html
+++ b/templates/home/new.html
@@ -359,7 +359,7 @@
                 "cache": {
                     "enable": false
                 },
-                "mode": "ir",
+                "mode": "wysiwyg",
                 "debugger": false,
                 "preview": {
                     "mode": "both",

--- a/templates/home/new_page.html
+++ b/templates/home/new_page.html
@@ -305,7 +305,7 @@
                 "cache": {
                     "enable": false
                 },
-                "mode": "ir",
+                "mode": "wysiwyg",
                 "debugger": false,
                 "preview": {
                     "mode": "both",


### PR DESCRIPTION
现发现 vditor 的 ir 模式有 bug，详见 <https://github.com/Vanessa219/vditor/issues/1476>。

该问题会导致：粘贴文本后，在存储时就会存储错误的文本。在该问题解决前，应该先把默认的编辑模式改回去。

此外还应该暂时禁用 ir 模式，但是我暂时不知道怎么解决该问题，只做了改回去的操作。