### PR TITLE
feat: 接入 Vercel Analytics（Web Analytics + Speed Insights）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 WORKERS=4
 THREADS=4
 TIMEOUT=600
+# Vercel Analytics（仅 Vercel 部署默认生效）
+# 不设置：在 Vercel 平台（VERCEL=1）自动开启 Web Analytics
+# true  / 1 / yes  -> 强制开启（非 Vercel 需同时设置 VERCEL_ANALYTICS_ENDPOINT）
+# false / 0 / no   -> 强制关闭
+VERCEL_ANALYTICS=
+# 非 Vercel 部署下启用 Analytics 的自定义采集端点（可选）
+VERCEL_ANALYTICS_ENDPOINT=

--- a/core/settings.py
+++ b/core/settings.py
@@ -66,6 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'hexoweb.functions.vercel_analytics',
             ],
         },
     },

--- a/hexoweb/functions.py
+++ b/hexoweb/functions.py
@@ -1441,3 +1441,30 @@ if UPDATE_FROM != "false" and UPDATE_FROM != "true" and UPDATE_FROM != QEXO_VERS
         logging.error(gettext("ELEVATOR_ERROR").format(str(e)))
     save_setting("UPDATE_FROM", QEXO_VERSION)
     save_setting("JUMP_UPDATE", "true")
+
+
+def vercel_analytics(request):
+    """向模板注入 Vercel Analytics 配置（仅 Vercel 部署默认启用）。
+
+    非 Vercel 部署默认不注入，保持页面原样；如需在非 Vercel 环境启用，
+    可设置 VERCEL_ANALYTICS_ENDPOINT 指向自定义采集端点。
+    需在 Vercel 后台开启 Analytics / Speed Insights 才会真正收集数据。
+    """
+    is_vercel = os.environ.get("VERCEL") == "1"
+    override = os.environ.get("VERCEL_ANALYTICS", "").lower()
+    if override == "false":
+        return {"VERCEL_ANALYTICS_SRC": ""}
+    if is_vercel or override == "true":
+        if is_vercel:
+            return {
+                "VERCEL_ANALYTICS_SRC": "/_vercel/insights/script.js",
+                "VERCEL_ANALYTICS_SPEED_SRC": "/_vercel/speed-insights/script.js",
+            }
+        # 非 Vercel 部署：仅当显式提供自定义端点时才启用
+        endpoint = os.environ.get("VERCEL_ANALYTICS_ENDPOINT")
+        if endpoint:
+            return {
+                "VERCEL_ANALYTICS_SRC": endpoint,
+                "VERCEL_ANALYTICS_SPEED_SRC": endpoint,
+            }
+    return {"VERCEL_ANALYTICS_SRC": ""}

--- a/hexoweb/functions.py
+++ b/hexoweb/functions.py
@@ -1450,21 +1450,21 @@ def vercel_analytics(request):
     可设置 VERCEL_ANALYTICS_ENDPOINT 指向自定义采集端点。
     需在 Vercel 后台开启 Analytics / Speed Insights 才会真正收集数据。
     """
-    is_vercel = os.environ.get("VERCEL") == "1"
-    override = os.environ.get("VERCEL_ANALYTICS", "").lower()
-    if override == "false":
+    is_vercel = bool(os.environ.get("VERCEL"))
+    override = os.environ.get("VERCEL_ANALYTICS")
+    # 未显式设置时跟随 Vercel 环境自动探测；显式设置则用 _as_bool_value 解析（支持 true/1/yes/是 等）
+    if not _as_bool_value(override, default=is_vercel):
         return {"VERCEL_ANALYTICS_SRC": ""}
-    if is_vercel or override == "true":
-        if is_vercel:
-            return {
-                "VERCEL_ANALYTICS_SRC": "/_vercel/insights/script.js",
-                "VERCEL_ANALYTICS_SPEED_SRC": "/_vercel/speed-insights/script.js",
-            }
-        # 非 Vercel 部署：仅当显式提供自定义端点时才启用
-        endpoint = os.environ.get("VERCEL_ANALYTICS_ENDPOINT")
-        if endpoint:
-            return {
-                "VERCEL_ANALYTICS_SRC": endpoint,
-                "VERCEL_ANALYTICS_SPEED_SRC": endpoint,
-            }
+    if is_vercel:
+        return {
+            "VERCEL_ANALYTICS_SRC": "/_vercel/insights/script.js",
+            "VERCEL_ANALYTICS_SPEED_SRC": "/_vercel/speed-insights/script.js",
+        }
+    # 非 Vercel 部署：仅在显式提供自定义端点时启用
+    endpoint = os.environ.get("VERCEL_ANALYTICS_ENDPOINT")
+    if endpoint:
+        return {
+            "VERCEL_ANALYTICS_SRC": endpoint,
+            "VERCEL_ANALYTICS_SPEED_SRC": endpoint,
+        }
     return {"VERCEL_ANALYTICS_SRC": ""}

--- a/templates/includes/scripts.html
+++ b/templates/includes/scripts.html
@@ -425,3 +425,5 @@
         100% { width: 0; }
     }
 </style>
+
+    {% include "includes/vercel-analytics.html" %}

--- a/templates/includes/vercel-analytics.html
+++ b/templates/includes/vercel-analytics.html
@@ -1,0 +1,21 @@
+{% comment %}
+Vercel Analytics 注入片段
+- 仅在 VERCEL_ANALYTICS_SRC 非空时输出（由 hexoweb.functions.vercel_analytics 控制）
+- Vercel 部署（VERCEL=1）默认启用官方采集脚本
+- 非 Vercel 部署默认不注入；如需启用，设置 VERCEL_ANALYTICS_ENDPOINT 指向自定义端点
+- 脚本加载失败通过 onerror 静默移除，不影响其它功能
+- 需在 Vercel 后台开启 Analytics / Speed Insights 才会真正收集数据
+{% endcomment %}
+{% if VERCEL_ANALYTICS_SRC %}
+    {# Vercel Web Analytics #}
+    <script>
+        window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+    </script>
+    <script defer src="{{ VERCEL_ANALYTICS_SRC }}" onerror="this.remove()"></script>
+
+    {# Vercel Speed Insights #}
+    <script>
+        window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
+    </script>
+    <script defer src="{{ VERCEL_ANALYTICS_SPEED_SRC }}" onerror="this.remove()"></script>
+{% endif %}


### PR DESCRIPTION
## 概述
为 Qexo 接入 Vercel 官方分析能力（Web Analytics 访问统计 + Speed Insights 性能监控），适用于以 Vercel 部署的场景。实现方式对现有功能**零侵入**。

## 改动内容
- 新增 `templates/includes/vercel-analytics.html`：在 `{% if VERCEL_ANALYTICS_SRC %}` 内包裹 Vercel 采集脚本（insights + speed-insights），脚本加载失败通过 `onerror` 静默移除
- `hexoweb/functions.py`：新增上下文处理器 `vercel_analytics()`（未单独新建 Python 文件），向所有模板注入 `VERCEL_ANALYTICS_SRC` / `VERCEL_ANALYTICS_SPEED_SRC`
- `core/settings.py`：在 `TEMPLATES.context_processors` 注册上述处理器（仅 +1 行）
- `templates/includes/scripts.html`：末尾 `{% include %}` 引入 analytics 片段（两个 base 布局均包含本文件，实现全页面覆盖）
- `.env.example`：补充 `VERCEL_ANALYTICS` / `VERCEL_ANALYTICS_ENDPOINT` 说明

## 启用方式
- 默认：检测到 `VERCEL` 环境变量（非空）即视为 Vercel 部署并自动开启官方脚本
- 强制控制：设置 `VERCEL_ANALYTICS=true/false`（支持 `true/1/yes/是` 等价写法，`false/0/no/否` 关闭）
- 非 Vercel 部署：默认不注入；如需启用，设置 `VERCEL_ANALYTICS_ENDPOINT` 指向自定义采集端点
- 需在 **Vercel 后台启用 Analytics / Speed Insights**，采集脚本才会真正上报数据

## 说明
已根据 review 意见调整：推送至 `dev` 分支；对非 Vercel 部署做区别处理；不再新增独立的 Python 文件。